### PR TITLE
fix: don't update scripts/smoke.sh

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,3 +1,4 @@
 CODEOWNERS
 dependabot.yml
 scripts/.util/tools.json
+scripts/smoke.sh


### PR DESCRIPTION
It needs to set the experimental option to true which is not in the shared version of the script for smoke tests

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Avoid the custom version of the smoke script from being overwritten

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
