### PR TITLE
ensure push-image.yml is not updated

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,4 +1,5 @@
 CODEOWNERS
 dependabot.yml
+.github/workflows/push-image.yml
 scripts/.util/tools.json
 scripts/smoke.sh


### PR DESCRIPTION
It currently differs from the shared version

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Don't update push-image.yml as we cannot use the shared version for now

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
