### PR TITLE
Moving functions for creating and removing local registry from tools.sh to smoke.sh

### DIFF
--- a/scripts/.util/tools.sh
+++ b/scripts/.util/tools.sh
@@ -173,29 +173,3 @@ function util::tools::tests::checkfocus() {
   fi
   rm "${testout}"
 }
-
-function util::tools::setup_local_registry() {
-
-  registry_port="${1}"
-
-  local registry_container_id
-  if [[ "$(curl -s -o /dev/null -w "%{http_code}" localhost:$registry_port/v2/)" == "200" ]]; then
-    registry_container_id=""
-  else
-    registry_container_id=$(docker run -d -p "${registry_port}:5000" --restart=always registry:2)
-  fi
-
-  echo $registry_container_id
-}
-
-function util::tools::cleanup_local_registry() {
-  local registry_container_id
-  registry_container_id="${1}"
-
-  util::print::title "inside cleanup $registry_container_id"
-
-  if [[ -n "${registry_container_id}" ]]; then
-    docker stop $registry_container_id
-    docker rm $registry_container_id
-  fi
-}

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -141,4 +141,28 @@ function tests::run() {
   popd > /dev/null
 }
 
+function util::tools::setup_local_registry() {
+
+  registry_port="${1}"
+
+  local registry_container_id
+  if [[ "$(curl -s -o /dev/null -w "%{http_code}" localhost:$registry_port/v2/)" == "200" ]]; then
+    registry_container_id=""
+  else
+    registry_container_id=$(docker run -d -p "${registry_port}:5000" --restart=always registry:2)
+  fi
+
+  echo $registry_container_id
+}
+
+function util::tools::cleanup_local_registry() {
+  local registry_container_id
+  registry_container_id="${1}"
+
+  if [[ -n "${registry_container_id}" ]]; then
+    docker stop $registry_container_id
+    docker rm $registry_container_id
+  fi
+}
+
 main "${@:-}"


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Paketo bot tries to sync tools.sh and due the original tools.sh file does not include the functions for spawning and removing local registry, it removes them from this repo and as a result the tests fail https://github.com/paketo-community/builder-ubi-base/pull/67. The solution is to move these functions inside the smoke.sh script which does not get synchronized by the paketo bot. 

## Use Cases
<!-- An explanation of the use cases your change enables -->
This PR will solve this issue https://github.com/paketo-community/builder-ubi-base/pull/67

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
