### PR TITLE
Adding action for updating crane version

### DIFF
--- a/.github/.syncignore
+++ b/.github/.syncignore
@@ -1,2 +1,3 @@
 CODEOWNERS
 dependabot.yml
+workflows/update-tools.yml

--- a/.github/workflows/update-builder-toml.yml
+++ b/.github/workflows/update-builder-toml.yml
@@ -2,7 +2,7 @@ name: Update builder.toml and Send Pull Request
 
 on:
   schedule:
-  - cron: '36 0,12 * * *' # daily at 00:36 and 12:36 UTC
+  - cron: '36 0,12 * * *'   # daily at 00:36 and 12:36 UTC
   workflow_dispatch: {}
 
 concurrency: builder_update

--- a/.github/workflows/update-github-config.yml
+++ b/.github/workflows/update-github-config.yml
@@ -2,7 +2,7 @@ name: Update shared github-config
 
 on:
   schedule:
-  - cron: '47 8 * * *' # daily at 08:46 UTC
+  - cron: '47 8 * * *'   # daily at 08:46 UTC
   workflow_dispatch: {}
 
 concurrency: github_config_update

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -1,0 +1,90 @@
+---
+name: Update Tools
+
+on:
+  schedule:
+  - cron: '42 19 * * *'   # daily at 19:42 UTC
+  workflow_dispatch: {}
+
+concurrency: tools_update
+
+jobs:
+  update:
+    name: Update
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Checkout Branch
+      uses: paketo-buildpacks/github-config/actions/pull-request/checkout-branch@main
+      with:
+        branch: automation/tools/update
+
+    - name: Fetch Latest pack
+      id: latest-pack
+      uses: paketo-buildpacks/github-config/actions/tools/latest@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        repo: buildpacks/pack
+
+    - name: Fetch Latest crane
+      id: latest-crane
+      uses: paketo-buildpacks/github-config/actions/tools/latest@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        repo: google/go-containerregistry
+
+    - name: Update builder tools.json
+      env:
+        PACK_VERSION: ${{ steps.latest-pack.outputs.version }}
+        CRANE_VERSION: ${{ steps.latest-crane.outputs.version }}
+      run: |
+        jq --null-input \
+           --sort-keys \
+           --arg pack "${PACK_VERSION}" \
+           --arg crane "${CRANE_VERSION}" \
+           '{ pack: $pack, crane: $crane, }' > ./scripts/.util/tools.json
+
+    - name: Commit
+      id: commit
+      uses: paketo-buildpacks/github-config/actions/pull-request/create-commit@main
+      with:
+        message: "Updating tools"
+        pathspec: "."
+        keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+
+    - name: Push Branch
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/push-branch@main
+      with:
+        branch: automation/tools/update
+
+    - name: Open Pull Request
+      if: ${{ steps.commit.outputs.commit_sha != '' }}
+      uses: paketo-buildpacks/github-config/actions/pull-request/open@main
+      with:
+        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
+        title: "Updates tools"
+        branch: automation/tools/update
+
+
+  failure:
+    name: Alert on Failure
+    runs-on: ubuntu-22.04
+    needs: [update]
+    if: ${{ always() && needs.update.result == 'failure' }}
+    steps:
+    - name: File Failure Alert Issue
+      uses: paketo-buildpacks/github-config/actions/issue/file@main
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        repo: ${{ github.repository }}
+        label: "failure:update-tools"
+        comment_if_exists: true
+        issue_title: "Failure: Update Tools workflow"
+        issue_body: |
+          Update Tools workflow [failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}).
+        comment_body: |
+           Another failure occurred: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/scripts/.syncignore
+++ b/scripts/.syncignore
@@ -1,2 +1,4 @@
 smoke.sh
 options.json
+tools.json
+tools.sh


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR adds functionality for updating the crane and pack tools versions that are on the `scripts/.util/tools.json` file.
This functionality is necessary as there is no action on github-config for updating crane.

It also excludes tools.json and tools.sh from syncing with github-config as they are different.

After merging this PR
1. Close this PR and also delete the branch

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
