### PR TITLE
Setting correct PGP key on the update tools actions

### DIFF
--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -81,7 +81,7 @@ jobs:
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         repo: ${{ github.repository }}
-        label: "failure:update-tools"
+        label: "failure:update-github-config"
         comment_if_exists: true
         issue_title: "Failure: Update Tools workflow"
         issue_body: |

--- a/.github/workflows/update-tools.yml
+++ b/.github/workflows/update-tools.yml
@@ -53,7 +53,7 @@ jobs:
         message: "Updating tools"
         pathspec: "."
         keyid: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
-        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY_ID }}
+        key: ${{ secrets.PAKETO_BOT_GPG_SIGNING_KEY }}
 
     - name: Push Branch
       if: ${{ steps.commit.outputs.commit_sha != '' }}


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR :
* corrects the PGP key that is being used on the update tools workflow.
* When there is a failure, adds a label that is available.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
